### PR TITLE
Fix quantity selector for one-of-a-kind items

### DIFF
--- a/js/simpleStore.js
+++ b/js/simpleStore.js
@@ -170,7 +170,7 @@ var simpleStore = {
 
     renderProductPageOptions: function (option) {
         if (option.OneOfAKind) {
-            $('.item_qty').hide();
+            $('.qty').hide();
         }
     },
 


### PR DESCRIPTION
The tag for the quantity selector in `index.html` has changed to `.qty`, need to update `simpleStore.js`.